### PR TITLE
Remove annoying dev version banner

### DIFF
--- a/client/components/common/nav-header.vue
+++ b/client/components/common/nav-header.vue
@@ -241,12 +241,6 @@
     page-selector(mode='create', v-model='duplicateOpts.modal', :open-handler='pageDuplicateHandle', :path='duplicateOpts.path', :locale='duplicateOpts.locale')
     page-delete(v-model='deletePageModal', v-if='path && path.length')
     page-convert(v-model='convertPageModal', v-if='path && path.length')
-
-    .nav-header-dev(v-if='isDevMode')
-      v-icon mdi-alert
-      div
-        .overline DEVELOPMENT VERSION
-        .overline This code base is NOT for production use!
 </template>
 
 <script>
@@ -282,7 +276,6 @@ export default {
       convertPageModal: false,
       deletePageModal: false,
       locales: siteLangs,
-      isDevMode: false,
       duplicateOpts: {
         locale: 'en',
         path: 'new-page',
@@ -369,7 +362,6 @@ export default {
     this.$root.$on('pageDelete', () => {
       this.pageDelete()
     })
-    this.isDevMode = siteConfig.devMode === true
   },
   methods: {
     searchFocus () {


### PR DESCRIPTION
This removes the **DEVELOPMENT VERSION** banner in the top left, even if we are in development, since this code is intended to be used in production.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/56cebc29-6f9e-4ea0-8765-a059c669026d) | ![image](https://github.com/user-attachments/assets/fc1f3fd2-e14f-4d93-a6cd-7fdb07193d4e) |