### PR TITLE
Use Bluesky API for user info

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "node": ">=10.12"
   },
   "dependencies": {
-    "@atproto/api": "0.13.9",
     "@atproto/jwk-jose": "0.1.2",
     "@atproto/oauth-client-node": "0.1.2",
     "@azure/storage-blob": "12.12.0",

--- a/server/modules/authentication/atproto/authentication.js
+++ b/server/modules/authentication/atproto/authentication.js
@@ -4,10 +4,10 @@
 // Auth0 Account
 // ------------------------------------
 
+const request = require('request-promise')
 const CustomStrategy = require('passport-custom').Strategy
 const { JoseKey } = require('@atproto/jwk-jose')
 const ATProto = require('@atproto/oauth-client-node')
-const { Agent } = require('@atproto/api')
 
 const states = new Map()
 const sessions = new Map()
@@ -97,10 +97,15 @@ module.exports = {
 
         console.log('User authenticated as:', session.did)
 
-        const agent = new Agent(session)
+        const url = new URL('https://api.bsky.app/xrpc/app.bsky.actor.getProfile')
+        url.searchParams.set('actor', session.did)
 
-        // Make Authenticated API calls
-        const { data } = await agent.getProfile({ actor: agent.did })
+        const data = await request({
+          method: 'GET',
+          uri: url.href,
+          json: true
+        })
+
         const user = await WIKI.models.users.processProfile({
           providerKey: req.params.strategy,
           profile: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,20 +270,6 @@
   resolved "https://registry.yarnpkg.com/@atproto-labs/simple-store/-/simple-store-0.1.1.tgz#e743a2722b5d8732166f0a72aca8bd10e9bff106"
   integrity sha512-WKILW2b3QbAYKh+w5U2x6p5FqqLl0nAeLwGeDY+KjX01K4Dq3vQTR9b/qNp0jZm48CabPQVrqCv0PPU9LgRRRg==
 
-"@atproto/api@0.13.9":
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.9.tgz#51fffcb21b481205bc2d5a54cac4fcdf1ea202df"
-  integrity sha512-mObrN+r+VCa0VQhaTeI7dCY7kgLCpybvRAQpHX/Qd6JBnAHZEOZdjWRswS1cNRM2rCATQMhXUH2Yn0ZPFbrTYw==
-  dependencies:
-    "@atproto/common-web" "^0.3.1"
-    "@atproto/lexicon" "^0.4.2"
-    "@atproto/syntax" "^0.3.0"
-    "@atproto/xrpc" "^0.6.3"
-    await-lock "^2.2.2"
-    multiformats "^9.9.0"
-    tlds "^1.234.0"
-    zod "^3.23.8"
-
 "@atproto/common-web@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.3.1.tgz#86f8efb10a4b9073839cee914c6c08a664917cc4"
@@ -382,7 +368,7 @@
   resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.3.0.tgz#fafa2dbea9add37253005cb663e7373e05e618b3"
   integrity sha512-Weq0ZBxffGHDXHl9U7BQc2BFJi/e23AL+k+i5+D9hUq/bzT4yjGsrCejkjq0xt82xXDjmhhvQSZ0LqxyZ5woxA==
 
-"@atproto/xrpc@0.6.3", "@atproto/xrpc@^0.6.3":
+"@atproto/xrpc@0.6.3":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.3.tgz#5942fc24644ad182b913af526efaa06a43d89478"
   integrity sha512-S3tRvOdA9amPkKLll3rc4vphlDitLrkN5TwWh5Tu/jzk7mnobVVE3akYgICV9XCNHKjWM+IAPxFFI2qi+VW6nQ==
@@ -5566,11 +5552,6 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
-
-await-lock@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
-  integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
 
 aws-sdk@2.1309.0:
   version "2.1309.0"
@@ -19420,11 +19401,6 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-
-tlds@^1.234.0:
-  version "1.255.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.255.0.tgz#53c2571766c10da95928c716c48dfcf141341e3f"
-  integrity sha512-tcwMRIioTcF/FcxLev8MJWxCp+GUALRhFEqbDoZrnowmKSGqPrl5pqS+Sut2m8BgJ6S4FExCSSpGffZ0Tks6Aw==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
This replaces the need for users to grant the `transition:generic` atproto scope, since we can just load their data from the public Bluesky API based on the DID.
