### PR TITLE
Prevent editing display name

### DIFF
--- a/client/components/profile/profile.vue
+++ b/client/components/profile/profile.vue
@@ -25,29 +25,6 @@
               v-list-item-content
                 v-list-item-title {{$t('profile:displayName')}}
                 v-list-item-subtitle {{ user.name }}
-              v-list-item-action
-                v-menu(
-                  v-model='editPop.name'
-                  :close-on-content-click='false'
-                  min-width='350'
-                  left
-                  )
-                  template(v-slot:activator='{ on }')
-                    v-btn(text, color='grey', small, v-on='on', @click='focusField(`iptDisplayName`)')
-                      v-icon(left) mdi-pencil
-                      span {{ $t('common:actions:edit') }}
-                  v-card
-                    v-text-field(
-                      ref='iptDisplayName'
-                      v-model='user.name'
-                      :label='$t(`profile:displayName`)'
-                      solo
-                      hide-details
-                      append-icon='mdi-check'
-                      @click:append='editPop.name = false'
-                      @keydown.enter='editPop.name = false'
-                      @keydown.esc='editPop.name = false'
-                    )
             v-divider
             v-list-item
               v-list-item-avatar(size='32')

--- a/server/graph/resolvers/user.js
+++ b/server/graph/resolvers/user.js
@@ -192,7 +192,6 @@ module.exports = {
 
         await WIKI.models.users.updateUser({
           id: usr.id,
-          name: _.trim(args.name),
           jobTitle: _.trim(args.jobTitle),
           location: _.trim(args.location),
           timezone: args.timezone,


### PR DESCRIPTION
This prevents users from editing their display name. This is relevant
because for atproto users, their display name corresponds to their
current handle in atproto. The user shouldn’t get to overwrite it, which
could allow impersonation.

Note that admins can still change display names.