### PR TITLE
Add avatars to comments

### DIFF
--- a/client/components/comments.vue
+++ b/client/components/comments.vue
@@ -78,8 +78,8 @@
         )
         template(v-slot:icon)
           v-avatar(color='blue-grey')
-            //- v-img(src='http://i.pravatar.cc/64')
-            span.white--text.title {{cm.initials}}
+            v-img(v-if='cm.authorPicture', :src='cm.authorPicture')
+            span.white--text.title(v-else) {{cm.initials}}
         v-card.elevation-1
           v-card-text
             .comments-post-actions(v-if='permissions.manage && !isBusy && commentEditId === 0')
@@ -183,6 +183,7 @@ export default {
                   id
                   render
                   authorName
+                  authorPicture
                   createdAt
                   updatedAt
                 }

--- a/server/graph/resolvers/comment.js
+++ b/server/graph/resolvers/comment.js
@@ -47,11 +47,13 @@ module.exports = {
         })
       if (page) {
         if (WIKI.auth.checkAccess(context.req.user, ['read:comments'], { tags: page.tags, ...args })) {
-          const comments = await WIKI.models.comments.query().where('pageId', page.id).orderBy('createdAt')
+          const comments = await WIKI.models.comments.query().where('pageId', page.id).orderBy('createdAt').withGraphFetched('author')
+          console.log(comments)
           return comments.map(c => ({
             ...c,
             authorName: c.name,
             authorEmail: c.email,
+            authorPicture: c.author?.pictureUrl,
             authorIP: c.ip
           }))
         } else {

--- a/server/graph/schemas/comment.graphql
+++ b/server/graph/schemas/comment.graphql
@@ -81,6 +81,7 @@ type CommentPost {
   render: String!
   authorId: Int!
   authorName: String!
+  authorPicture: String
   authorEmail: String! @auth(requires: ["manage:system"])
   authorIP: String! @auth(requires: ["manage:system"])
   createdAt: Date!


### PR DESCRIPTION
This adds avatars to comments (if there an associated account exists that has a `pictureUrl` set).

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4cf713b7-da9d-4a5b-afd0-aa55abad7897) | ![image](https://github.com/user-attachments/assets/64355427-2356-4c1d-8e24-c0c8669869bb) |