### PR TITLE
Change atproto email hostname to just atproto

### DIFF
--- a/server/modules/authentication/atproto/authentication.js
+++ b/server/modules/authentication/atproto/authentication.js
@@ -113,7 +113,7 @@ module.exports = {
             id: data.did,
             displayName: data.handle,
             picture: data.avatar,
-            email: data.did.replace(/:/g, '_') + '@atproto.invalid'
+            email: data.did.replace(/:/g, '_') + '@atproto'
           }
         })
         done(null, user)


### PR DESCRIPTION
This changes the atproto email hostname to just `atproto` instead of `atproto.invalid` to use a hostname that will likely never be present on the real internet (in case we eventually get a `.invalid` TLD). This will also look better in the UI.
